### PR TITLE
Add Japanese language support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@ This repository contains a multilingual website celebrating various days related
 For JavaScript and TypeScript code, use double quotes for strings and follow the project's Prettier configuration.
 
 When working with internationalization (i18n):
+
 - The project currently supports English (en) and Korean (ko) languages
 - English is the default and fallback language
 - When adding new language support, update these files:
@@ -12,6 +13,7 @@ When working with internationalization (i18n):
   4. Update `src/data/day/README.md` to list the newly supported language
 
 When adding new days to the Fediverse calendar:
+
 - Add YAML files to `src/data/day` directory
 - Follow the format specified in `src/data/day/README.md`
 - Ensure dates are in `YYYY-MM-DD` format
@@ -20,11 +22,13 @@ When adding new days to the Fediverse calendar:
 - Provide translations for supported languages when possible
 
 For Astro components:
+
 - Use React-style props with TypeScript interfaces
 - Leverage Tailwind CSS for styling
 - Follow the existing component patterns in the project
 
 This project uses:
+
 - Astro framework
 - TypeScript
 - Tailwind CSS

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
     locales: [
       "en",
       "ko",
+      "ja",
       // Add new locale here
     ],
     defaultLocale: "en",

--- a/src/data/day/README.md
+++ b/src/data/day/README.md
@@ -20,8 +20,9 @@ name:
   # Required. Fallback language
   en: Fediverse Day
   # You can add other language
-  # Currently supported languages: ko
+  # Currently supported languages: ko, ja
   #ko: 연합우주의 날
+  #ja: フェディバースの日
 
 # Description of the day
 # Optional
@@ -29,6 +30,7 @@ description:
   # If you want to provide description, `en` field is required. Fallback language
   en: The day of the Fediverse of the Fediversian people!
   # You can add other language
-  # Currently supported languages: ko
+  # Currently supported languages: ko, ja
   #ko: 연합우주인들의 연합우주의 날
+  #ja: フェディバースの人々のフェディバースの日
 ```

--- a/src/data/day/fediday.yaml
+++ b/src/data/day/fediday.yaml
@@ -2,3 +2,5 @@ date: "2025-04-11"
 name:
   en: Federated Fediverse Day
   ko: 연합형 연합우주의 날
+  ja: 連合型フェディバースの日
+

--- a/src/data/day/mastodon-nil-nu.yaml
+++ b/src/data/day/mastodon-nil-nu.yaml
@@ -1,0 +1,10 @@
+date: "2017-04-11"
+link: https://mstdn.jp/
+name:
+  en: Birth of mastodon.nil.nu (mstdn.jp)
+  ko: mastodon.nil.nu (mstdn.jp) 탄생일
+  ja: mastodon.nil.nu（mstdn.jp）の誕生日
+description:
+  en: The day mastodon.nil.nu, which later became mstdn.jp, was established. This instance became one of the largest Japanese Mastodon servers and played a key role in popularizing the fediverse in Japan.
+  ko: 후에 mstdn.jp가 된 mastodon.nil.nu가 설립된 날. 이 인스턴스는 일본에서 가장 큰 마스토돈 서버 중 하나가 되었으며 일본에서 연합우주의 대중화에 중요한 역할을 했습니다.
+  ja: 後にmstdn.jpとなるmastodon.nil.nuが設立された日。このインスタンスは日本最大級のMastodonサーバーとなり、日本におけるフェディバースの普及に重要な役割を果たしました。

--- a/src/data/day/planet.yaml
+++ b/src/data/day/planet.yaml
@@ -1,8 +1,10 @@
 date: "2017-10-23"
-link: https://planet.moe
+link: https://planet.moe/
 name:
   en: Founding of planet.moe
   ko: 플래닛 설립일
+  ja: planet.moeの設立
 description:
   en: The day planet.moe was born as a Mastodon instance
   ko: 플래닛이 마스토돈 인스턴스로써 세상에 나온 날
+  ja: planet.moeがMastodonインスタンスとして誕生した日

--- a/src/data/day/reni-birthday.yaml
+++ b/src/data/day/reni-birthday.yaml
@@ -1,8 +1,11 @@
 date: "2016-08-26"
-link: https://planet.moe
+link: https://planet.moe/
 name:
   en: Birth of Reni
   ko: 레니의 탄생일
+  ja: レニの誕生日
 description:
   en: Birth of Reni, the mascot of planet.moe
   ko: 플래닛의 마스코트 캐릭터 레니의 탄생일
+  ja: planet.moeのマスコット、レニの誕生日
+

--- a/src/data/day/yuri.garden.yaml
+++ b/src/data/day/yuri.garden.yaml
@@ -1,8 +1,10 @@
 date: "2023-07-17"
-link: https://yuri.garden
+link: https://yuri.garden/
 name:
   en: Birth of yuri.garden
   ko: 백합.정원 탄생일
+  ja: 百合.庭園の誕生日
 description:
   en: Birth of the yuri-themed Misskey instance, yuri.garden
   ko: 백합 주제 미스키 인스턴스, 백합.정원의 탄생일
+  ja: 百合テーマのMisskeyインスタンス、百合.庭園の誕生日

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,7 +24,7 @@ import { getRelativeLocaleUrl } from "astro:i18n";
               class="text-blue-600 underline text-lg"
               href={getRelativeLocaleUrl(lang, "")}
             >
-              {lang}
+              {new Intl.DisplayNames([lang], { type: "language" }).of(lang)}
             </a>
           ))
         }

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -1,0 +1,51 @@
+---
+import Layout from "@layouts/Layout.astro";
+import "@styles/global.css";
+import Days from "@layouts/Days.astro";
+import Quote1 from "@components/quote/pbzweihander.html";
+import Quote2 from "@components/quote/dazeemdas.html";
+import Quote3 from "@components/quote/robin_maki.html";
+---
+
+<Layout>
+  <h1 class="text-3xl font-bold text-center mb-10">
+    フェディバースの日、おめでとう！
+  </h1>
+  <h2 class="text-xl text-center mb-4">
+    フェディバースの日は（たぶん）今日です！
+  </h2>
+  <p class="w-2xl mx-auto mb-10">
+    毎日がフェディバースの日になれます！フェディバースの連合型の性質に従って、
+    フェディバースに関連するすべての記念日を祝っています。
+    つまり、<b>連合型フェディバースの日</b>です！
+  </p>
+  <h2 class="text-xl text-center mb-4">背景</h2>
+  <div class="flex gap-2 justify-center items-stretch mb-4">
+    <div class="w-sm">
+      <Quote1 />
+    </div>
+    <div class="w-sm">
+      <Quote2 />
+    </div>
+    <div class="w-sm">
+      <Quote3 />
+    </div>
+  </div>
+  <p class="w-2xl mx-auto mb-10 break-keep">
+    あるユーザーが「フェディバースの日はないのか？」と言及した日を祝います。
+    その日、4月11日を<b>連合型フェディバースの日</b>と呼びます。
+  </p>
+  <h2 class="text-xl text-center mb-4">
+    祝うべき日はたくさんあります
+  </h2>
+  <div class="w-3xl mx-auto mb-20">
+    <Days lang="ja" />
+  </div>
+  <h2 class="text-center text-2xl text-bold mb-20">
+    新しい日を追加したいですか？<a
+      class="text-blue-600 underline"
+      href="https://github.com/pbzweihander/fediday.org"
+      target="_blank">GitHubリポジトリ</a
+    >にPRまたはissueを送ってください！
+  </h2>
+</Layout>

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -19,16 +19,29 @@ import Quote3 from "@components/quote/robin_maki.html";
     フェディバースに関連するすべての記念日を祝っています。
     つまり、<b>連合型フェディバースの日</b>です！
   </p>
-  <h2 class="text-xl text-center mb-4">背景</h2>
+  <h2 class="text-xl text-center mb-4">
+    制定されるに至ったきっかけ
+  </h2>
   <div class="flex gap-2 justify-center items-stretch mb-4">
     <div class="w-sm">
       <Quote1 />
+      <div class="text-gray-500 text-sm p-1">
+        そうか、フェディバースの日とか無いのか？ 
+        無ければ、我々同士で決めて記念してもいいんじゃないか？
+        せめて韓国語圏のフェディバースの日とか決めてもいいんじゃないか？
+      </div>
     </div>
     <div class="w-sm">
       <Quote2 />
+      <div class="text-gray-500 text-sm p-1">
+        今日はフェディバースの日です。
+      </div>
     </div>
     <div class="w-sm">
       <Quote3 />
+      <div class="text-gray-500 text-sm p-1">
+        フェディバースの日：フェディバースの日を制定しようという日を記念する。
+      </div>
     </div>
   </div>
   <p class="w-2xl mx-auto mb-10 break-keep">

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -16,17 +16,16 @@ import Quote3 from "@components/quote/robin_maki.html";
   </h2>
   <p class="w-2xl mx-auto mb-10">
     毎日がフェディバースの日になれます！フェディバースの連合型の性質に従って、
-    フェディバースに関連するすべての記念日を祝っています。
-    つまり、<b>連合型フェディバースの日</b>です！
+    フェディバースに関連するすべての記念日を祝っています。 つまり、<b
+      >連合型フェディバースの日</b
+    >です！
   </p>
-  <h2 class="text-xl text-center mb-4">
-    制定されるに至ったきっかけ
-  </h2>
+  <h2 class="text-xl text-center mb-4">制定されるに至ったきっかけ</h2>
   <div class="flex gap-2 justify-center items-stretch mb-4">
     <div class="w-sm">
       <Quote1 />
       <div class="text-gray-500 text-sm p-1">
-        そうか、フェディバースの日とか無いのか？ 
+        そうか、フェディバースの日とか無いのか？
         無ければ、我々同士で決めて記念してもいいんじゃないか？
         せめて韓国語圏のフェディバースの日とか決めてもいいんじゃないか？
       </div>
@@ -48,9 +47,7 @@ import Quote3 from "@components/quote/robin_maki.html";
     あるユーザーが「フェディバースの日はないのか？」と言及した日を祝います。
     その日、4月11日を<b>連合型フェディバースの日</b>と呼びます。
   </p>
-  <h2 class="text-xl text-center mb-4">
-    祝うべき日はたくさんあります
-  </h2>
+  <h2 class="text-xl text-center mb-4">祝うべき日はたくさんあります</h2>
   <div class="w-3xl mx-auto mb-20">
     <Days lang="ja" />
   </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { z } from "astro:content";
 const multiLanguageObject = z.object({
   en: z.string(),
   ko: z.string().optional(),
+  ja: z.string().optional(),
   // Add new locale here
 });
 export const languages = multiLanguageObject.keyof();


### PR DESCRIPTION
Add complete Japanese (`ja`) localization to the Fediverse Day website.

This allows Japanese-speaking users to fully experience the website in their native language while maintaining consistent terminology across all supported languages.