### PR TITLE
Fix carousel scroll on small screens

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,9 @@ import Quote3 from "@components/quote/robin_maki.html";
     So, a <b>Federated Fediverse Day</b>!
   </p>
   <h2 class="text-xl text-center mb-4">Background</h2>
-  <div class="flex gap-2 justify-center items-stretch mb-4 overflow-x-auto">
+  <div
+    class="flex gap-2 justify-center-safe items-stretch mb-4 overflow-x-auto"
+  >
     <div class="w-sm">
       <Quote1 />
       <div class="text-gray-500 text-sm p-1">

--- a/src/pages/ja/index.astro
+++ b/src/pages/ja/index.astro
@@ -21,7 +21,9 @@ import Quote3 from "@components/quote/robin_maki.html";
     >です！
   </p>
   <h2 class="text-xl text-center mb-4">制定されるに至ったきっかけ</h2>
-  <div class="flex gap-2 justify-center items-stretch mb-4">
+  <div
+    class="flex gap-2 justify-center-safe items-stretch mb-4 overflow-x-auto"
+  >
     <div class="w-sm">
       <Quote1 />
       <div class="text-gray-500 text-sm p-1">

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -21,7 +21,9 @@ import Quote3 from "@components/quote/robin_maki.html";
     >을 만들기로 했어요!
   </p>
   <h2 class="text-xl text-center mb-4">만들어지게 된 계기</h2>
-  <div class="flex gap-2 justify-center items-stretch mb-4">
+  <div
+    class="flex gap-2 justify-center-safe items-stretch mb-4 overflow-x-auto"
+  >
     <div class="w-sm">
       <Quote1 />
     </div>

--- a/src/pages/zh-cn/index.astro
+++ b/src/pages/zh-cn/index.astro
@@ -16,7 +16,9 @@ import Quote3 from "@components/quote/robin_maki.html";
     >！
   </p>
   <h2 class="text-xl text-center mb-4">背景</h2>
-  <div class="flex gap-2 justify-center items-stretch mb-4 overflow-x-auto">
+  <div
+    class="flex gap-2 justify-center-safe items-stretch mb-4 overflow-x-auto"
+  >
     <div class="w-sm">
       <Quote1 />
       <div class="text-gray-500 text-sm p-1">


### PR DESCRIPTION
Before: The first post is cropped and can't be scrolled to
<img width="298" alt="Screenshot 2025-05-28 at 10 16 18 AM" src="https://github.com/user-attachments/assets/58bd7340-9ffc-420f-9c63-40c80cb106e7" />

After: The first post appears and scrollable
<img width="298" alt="Screenshot 2025-05-28 at 10 16 54 AM" src="https://github.com/user-attachments/assets/4a4a37a2-cc8f-420d-93a9-9a0c1fe1af13" />

Solution is using `safe` https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content#safe